### PR TITLE
Adding rst generator script

### DIFF
--- a/build_rst.sh
+++ b/build_rst.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# ------------------------------------------------------------
+# Script to generate the html and .rst stubs to show the
+# ipynb within Sphinx generated docs
+#
+# Requires jupyter nbconvert
+# ------------------------------------------------------------
+set -e
+
+# Create a clean index.rst
+echo "
+Tutorials
+=========
+
+.. toctree::
+   :maxdepth: 2
+" > index.rst
+
+for filename in *.ipynb; do
+    jupyter nbconvert --to html $filename
+    name="${filename%.*}"
+
+    # Create stub rst
+    echo "$name
+----------------
+
+.. raw:: html
+   :file: $name.html
+" > $name.rst
+
+    # Add to index
+    echo "   $name" >> index.rst
+
+done


### PR DESCRIPTION
To integrate with sphinx documentation the ipython notebooks need to be converted to html and have a stub 

### This PR
Creates a script which uses nbconvert to convert the ipynb files to html and generates the index.rst and $name.rst stub file.
